### PR TITLE
Release 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## Release 2.2.2
 
+### Improvements
+- Check if specific set functions are supported (e.g. not for SIM300 or SAE)
+
 ### Bugfix
 - Legacy bindings of ValueDisplay elements within UI did not work if deployed with VS Code AppSpace SDK
 - UI differs if deployed via Appstudio or VS Code AppSpace SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Release 2.2.2
+
+### Bugfix
+- Legacy bindings of ValueDisplay elements within UI did not work if deployed with VS Code AppSpace SDK
+- UI differs if deployed via Appstudio or VS Code AppSpace SDK
+- Fullscreen icon of iFrame was visible
+
 ## Release 2.2.1
 
 ### Bugfix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Release 2.2.1
+
+### Bugfix
+- Error with adding new DNS server (introduced in version 2.2.0)
+
 ## Release 2.2.0
 
 ### New features

--- a/CSK_Module_DeviceNetworkConfig/pages/pages/CSK_Module_DeviceNetworkConfig/CSK_Module_DeviceNetworkConfig.css
+++ b/CSK_Module_DeviceNetworkConfig/pages/pages/CSK_Module_DeviceNetworkConfig/CSK_Module_DeviceNetworkConfig.css
@@ -52,5 +52,5 @@
 
 .myCustomButton_CSK_Module_DeviceNetworkConfig {
   border-radius: 30px;
-  padding-right: 0px;
+  padding: 11px;
 }

--- a/CSK_Module_DeviceNetworkConfig/pages/pages/CSK_Module_DeviceNetworkConfig/CSK_Module_DeviceNetworkConfig.html
+++ b/CSK_Module_DeviceNetworkConfig/pages/pages/CSK_Module_DeviceNetworkConfig/CSK_Module_DeviceNetworkConfig.html
@@ -88,138 +88,180 @@
                                             <curie-table-column id="MACAddress" header="MAC address">
                                             </curie-table-column>
                                         </curie-table>
-                                        <layout-row id="RowLayout5" style="align-items: center">
-                                            <layout-column id="ColumnLayout14" style="align-items: center">
-                                                <davinci-button id="Button_Refresh"
-                                                    class="myCustomButton_CSK_Module_DeviceNetworkConfig" type="outline"
-                                                    title="Refresh list">
-                                                    <davinci-icon icon="navigation/refresh"></davinci-icon>
-                                                    <span></span>
-                                                    <crown-binding event="submit" name="CSK_DeviceNetworkConfig/refresh"
-                                                        auto-commit>
-                                                    </crown-binding>
-                                                </davinci-button>
-                                            </layout-column>
-                                            <layout-column id="ColumnLayout3" style="align-items: center">
-                                                <davinci-value-display id="VD_SelectedInterface"
-                                                    class="myCustomMinWidth_CSK_Module_DeviceNetworkConfig">
-                                                    <crown-on property="label"
-                                                        crown-event="CSK_DeviceNetworkConfig/OnNewInterfaceChoice">
-                                                    </crown-on>
-                                                </davinci-value-display>
-                                            </layout-column>
-                                            <layout-column id="ColumnLayout7"
-                                                style="align-items: stretch; flex-grow: 3">
-                                                <layout-row id="RowLayout6" style="align-items: center">
-                                                    <davinci-value-display id="VD_IP" label="IPv4">
-                                                    </davinci-value-display>
-                                                    <davinci-text-field id="TF_IP" type="text">
-                                                        <crown-edpws-binding property="value"
-                                                            name="CSK_DeviceNetworkConfig/OnNewIP" update-on-resume>
-                                                        </crown-edpws-binding>
-                                                        <crown-edpws-binding property="error"
-                                                            name="CSK_DeviceNetworkConfig/OnIPError" update-on-resume>
-                                                        </crown-edpws-binding>
-                                                        <crown-edpws-binding property="disabled"
-                                                            name="CSK_DeviceNetworkConfig/OnIPDisabled"
-                                                            update-on-resume>
-                                                        </crown-edpws-binding>
-                                                        <crown-binding event="change"
-                                                            name="CSK_DeviceNetworkConfig/setInterfaceIP"
-                                                            path="param/args/newIP" auto-commit>
-                                                        </crown-binding>
-                                                    </davinci-text-field>
+                                        <stacked-view id="SV_NoSetFunctionSupport">
+                                            <stacked-pane id="SP_NoSetSupport" value="true">
+                                                <layout-row id="RowLayout23">
+                                                    <layout-column id="ColumnLayout20" style="align-items: stretch">
+                                                        <davinci-callout id="Callout_NoSetFunctions" type="info">
+                                                            <span>
+												Not possible to set configuration via this module. There might be other possiblities (e.g. OS or ControlCenter).
+												</span>
+                                                        </davinci-callout>
+                                                        <layout-row id="RowLayout24"
+                                                            class="myCustomSpacerVert10_CSK_Module_DeviceNetworkConfig"
+                                                            style="flex-grow: 0; flex-shrink: 0">
+                                                        </layout-row>
+                                                    </layout-column>
                                                 </layout-row>
-                                            </layout-column>
-                                            <layout-column id="ColumnLayout8"
-                                                style="align-items: stretch; flex-grow: 3">
-                                                <layout-row id="RowLayout7" style="align-items: center">
-                                                    <davinci-value-display id="VD_SubnetMask" label="Subnet mask">
-                                                    </davinci-value-display>
-                                                    <davinci-text-field id="TF_Subnet" type="text">
-                                                        <crown-edpws-binding property="value"
-                                                            name="CSK_DeviceNetworkConfig/OnNewSubnetMask"
-                                                            update-on-resume>
-                                                        </crown-edpws-binding>
-                                                        <crown-edpws-binding property="disabled"
-                                                            name="CSK_DeviceNetworkConfig/OnSubnetDisabled"
-                                                            update-on-resume>
-                                                        </crown-edpws-binding>
-                                                        <crown-edpws-binding property="error"
-                                                            name="CSK_DeviceNetworkConfig/OnSubnetError"
-                                                            update-on-resume>
-                                                        </crown-edpws-binding>
-                                                        <crown-binding event="change"
-                                                            name="CSK_DeviceNetworkConfig/setSubnetMask"
-                                                            path="param/args/newSubnetMask" auto-commit>
-                                                        </crown-binding>
-                                                    </davinci-text-field>
+                                            </stacked-pane>
+                                            <stacked-pane id="SP_SetSupported" value="false">
+                                                <layout-row id="RowLayout22">
+                                                    <layout-column id="ColumnLayout19" style="align-items: stretch">
+                                                        <layout-row id="RowLayout5" style="align-items: center">
+                                                            <layout-column id="ColumnLayout14"
+                                                                style="align-items: center">
+                                                                <davinci-button id="Button_Refresh"
+                                                                    class="myCustomButton_CSK_Module_DeviceNetworkConfig" type="outline"
+                                                                    title="Refresh list">
+                                                                    <davinci-icon icon="navigation/refresh">
+                                                                    </davinci-icon>
+                                                                    <span></span>
+                                                                    <crown-binding event="submit"
+                                                                        name="CSK_DeviceNetworkConfig/refresh"
+                                                                        auto-commit>
+                                                                    </crown-binding>
+                                                                </davinci-button>
+                                                            </layout-column>
+                                                            <layout-column id="ColumnLayout3"
+                                                                style="align-items: center">
+                                                                <davinci-value-display id="VD_SelectedInterface"
+                                                                    class="myCustomMinWidth_CSK_Module_DeviceNetworkConfig">
+                                                                    <crown-on property="label"
+                                                                        crown-event="CSK_DeviceNetworkConfig/OnNewInterfaceChoice">
+                                                                    </crown-on>
+                                                                </davinci-value-display>
+                                                            </layout-column>
+                                                            <layout-column id="ColumnLayout7"
+                                                                style="align-items: stretch; flex-grow: 3">
+                                                                <layout-row id="RowLayout6" style="align-items: center">
+                                                                    <davinci-value-display id="VD_IP" label="IPv4">
+                                                                    </davinci-value-display>
+                                                                    <davinci-text-field id="TF_IP" type="text"
+                                                                        autocomplete="on">
+                                                                        <crown-edpws-binding property="value"
+                                                                            name="CSK_DeviceNetworkConfig/OnNewIP"
+                                                                            update-on-resume>
+                                                                        </crown-edpws-binding>
+                                                                        <crown-edpws-binding property="error"
+                                                                            name="CSK_DeviceNetworkConfig/OnIPError"
+                                                                            update-on-resume>
+                                                                        </crown-edpws-binding>
+                                                                        <crown-edpws-binding property="disabled"
+                                                                            name="CSK_DeviceNetworkConfig/OnIPDisabled"
+                                                                            update-on-resume>
+                                                                        </crown-edpws-binding>
+                                                                        <crown-binding event="change"
+                                                                            name="CSK_DeviceNetworkConfig/setInterfaceIP"
+                                                                            path="param/args/newIP" auto-commit>
+                                                                        </crown-binding>
+                                                                    </davinci-text-field>
+                                                                </layout-row>
+                                                            </layout-column>
+                                                            <layout-column id="ColumnLayout8"
+                                                                style="align-items: stretch; flex-grow: 3">
+                                                                <layout-row id="RowLayout7" style="align-items: center">
+                                                                    <davinci-value-display id="VD_SubnetMask"
+                                                                        label="Subnet mask">
+                                                                    </davinci-value-display>
+                                                                    <davinci-text-field id="TF_Subnet" type="text"
+                                                                        autocomplete="on">
+                                                                        <crown-edpws-binding property="value"
+                                                                            name="CSK_DeviceNetworkConfig/OnNewSubnetMask"
+                                                                            update-on-resume>
+                                                                        </crown-edpws-binding>
+                                                                        <crown-edpws-binding property="disabled"
+                                                                            name="CSK_DeviceNetworkConfig/OnSubnetDisabled"
+                                                                            update-on-resume>
+                                                                        </crown-edpws-binding>
+                                                                        <crown-edpws-binding property="error"
+                                                                            name="CSK_DeviceNetworkConfig/OnSubnetError"
+                                                                            update-on-resume>
+                                                                        </crown-edpws-binding>
+                                                                        <crown-binding event="change"
+                                                                            name="CSK_DeviceNetworkConfig/setSubnetMask"
+                                                                            path="param/args/newSubnetMask" auto-commit>
+                                                                        </crown-binding>
+                                                                    </davinci-text-field>
+                                                                </layout-row>
+                                                            </layout-column>
+                                                            <layout-column id="ColumnLayout9"
+                                                                style="align-items: stretch; flex-grow: 3">
+                                                                <layout-row id="RowLayout8" style="align-items: center">
+                                                                    <davinci-value-display id="VD_DefaultGateway"
+                                                                        label="Default gateway">
+                                                                    </davinci-value-display>
+                                                                    <davinci-text-field id="TF_Gateway" type="text"
+                                                                        autocomplete="on">
+                                                                        <crown-edpws-binding property="value"
+                                                                            name="CSK_DeviceNetworkConfig/OnNewDefaultGateway"
+                                                                            update-on-resume>
+                                                                        </crown-edpws-binding>
+                                                                        <crown-edpws-binding property="disabled"
+                                                                            name="CSK_DeviceNetworkConfig/OnGatewayDisabled"
+                                                                            update-on-resume>
+                                                                        </crown-edpws-binding>
+                                                                        <crown-edpws-binding property="error"
+                                                                            name="CSK_DeviceNetworkConfig/OnGatewayError"
+                                                                            update-on-resume>
+                                                                        </crown-edpws-binding>
+                                                                        <crown-binding event="change"
+                                                                            name="CSK_DeviceNetworkConfig/setDefaultGateway"
+                                                                            path="param/args/newDefaultGateway"
+                                                                            auto-commit>
+                                                                        </crown-binding>
+                                                                    </davinci-text-field>
+                                                                </layout-row>
+                                                            </layout-column>
+                                                            <layout-column id="ColumnLayout10"
+                                                                style="align-items: stretch; flex-grow: 2; justify-content: center">
+                                                                <layout-row id="RowLayout9" style="align-items: center">
+                                                                    <davinci-value-display id="VD_DHCP"
+                                                                        label="DHCP enabled">
+                                                                    </davinci-value-display>
+                                                                    <davinci-checkbox id="CB_DHCP">
+                                                                        <span></span>
+                                                                        <crown-edpws-binding property="checked"
+                                                                            name="CSK_DeviceNetworkConfig/OnNewDHCPStatus"
+                                                                            update-on-resume>
+                                                                        </crown-edpws-binding>
+                                                                        <crown-edpws-binding property="disabled"
+                                                                            name="CSK_DeviceNetworkConfig/OnDHCPDisabled"
+                                                                            update-on-resume>
+                                                                        </crown-edpws-binding>
+                                                                        <crown-binding event="change"
+                                                                            name="CSK_DeviceNetworkConfig/setDHCPState"
+                                                                            path="param/args/newDHCPstate" auto-commit>
+                                                                        </crown-binding>
+                                                                    </davinci-checkbox>
+                                                                </layout-row>
+                                                            </layout-column>
+                                                            <layout-column id="ColumnLayout16"
+                                                                style="align-items: center">
+                                                                <davinci-button id="Button_ApplyNewConfig"
+                                                                    class="myCustomButton_CSK_Module_DeviceNetworkConfig" type="outline"
+                                                                    title="Apply new network configuration">
+                                                                    <davinci-icon icon="navigation/check">
+                                                                    </davinci-icon>
+                                                                    <span></span>
+                                                                    <crown-edpws-binding property="disabled"
+                                                                        name="CSK_DeviceNetworkConfig/OnApplyButtonDisabled"
+                                                                        update-on-resume>
+                                                                    </crown-edpws-binding>
+                                                                    <crown-binding event="submit"
+                                                                        name="CSK_DeviceNetworkConfig/applyConfig"
+                                                                        auto-commit>
+                                                                    </crown-binding>
+                                                                </davinci-button>
+                                                            </layout-column>
+                                                        </layout-row>
+                                                    </layout-column>
                                                 </layout-row>
-                                            </layout-column>
-                                            <layout-column id="ColumnLayout9"
-                                                style="align-items: stretch; flex-grow: 3">
-                                                <layout-row id="RowLayout8" style="align-items: center">
-                                                    <davinci-value-display id="VD_DefaultGateway"
-                                                        label="Default gateway">
-                                                    </davinci-value-display>
-                                                    <davinci-text-field id="TF_Gateway" type="text">
-                                                        <crown-edpws-binding property="value"
-                                                            name="CSK_DeviceNetworkConfig/OnNewDefaultGateway"
-                                                            update-on-resume>
-                                                        </crown-edpws-binding>
-                                                        <crown-edpws-binding property="disabled"
-                                                            name="CSK_DeviceNetworkConfig/OnGatewayDisabled"
-                                                            update-on-resume>
-                                                        </crown-edpws-binding>
-                                                        <crown-edpws-binding property="error"
-                                                            name="CSK_DeviceNetworkConfig/OnGatewayError"
-                                                            update-on-resume>
-                                                        </crown-edpws-binding>
-                                                        <crown-binding event="change"
-                                                            name="CSK_DeviceNetworkConfig/setDefaultGateway"
-                                                            path="param/args/newDefaultGateway" auto-commit>
-                                                        </crown-binding>
-                                                    </davinci-text-field>
-                                                </layout-row>
-                                            </layout-column>
-                                            <layout-column id="ColumnLayout10"
-                                                style="align-items: stretch; flex-grow: 2; justify-content: center">
-                                                <layout-row id="RowLayout9" style="align-items: center">
-                                                    <davinci-value-display id="VD_DHCP" label="DHCP enabled">
-                                                    </davinci-value-display>
-                                                    <davinci-checkbox id="CB_DHCP">
-                                                        <span></span>
-                                                        <crown-edpws-binding property="checked"
-                                                            name="CSK_DeviceNetworkConfig/OnNewDHCPStatus"
-                                                            update-on-resume>
-                                                        </crown-edpws-binding>
-                                                        <crown-edpws-binding property="disabled"
-                                                            name="CSK_DeviceNetworkConfig/OnDHCPDisabled"
-                                                            update-on-resume>
-                                                        </crown-edpws-binding>
-                                                        <crown-binding event="change"
-                                                            name="CSK_DeviceNetworkConfig/setDHCPState"
-                                                            path="param/args/newDHCPstate" auto-commit>
-                                                        </crown-binding>
-                                                    </davinci-checkbox>
-                                                </layout-row>
-                                            </layout-column>
-                                            <layout-column id="ColumnLayout16" style="align-items: center">
-                                                <davinci-button id="Button_ApplyNewConfig"
-                                                    class="myCustomButton_CSK_Module_DeviceNetworkConfig" type="outline"
-                                                    title="Apply new network configuration">
-                                                    <davinci-icon icon="navigation/check"></davinci-icon>
-                                                    <span></span>
-                                                    <crown-edpws-binding property="disabled"
-                                                        name="CSK_DeviceNetworkConfig/OnApplyButtonDisabled"
-                                                        update-on-resume>
-                                                    </crown-edpws-binding>
-                                                    <crown-binding event="submit"
-                                                        name="CSK_DeviceNetworkConfig/applyConfig" auto-commit>
-                                                    </crown-binding>
-                                                </davinci-button>
-                                            </layout-column>
-                                        </layout-row>
+                                            </stacked-pane>
+                                            <crown-edpws-binding property="value"
+                                                name="CSK_DeviceNetworkConfig/OnNewStatusSetFunctionsNotSupported"
+                                                update-on-resume converter="function(value) {return value.toString();}">
+                                            </crown-edpws-binding>
+                                        </stacked-view>
                                     </layout-column>
                                 </layout-row>
                                 <layout-row id="RowLayout19" class="myCustomSpacerVert10_CSK_Module_DeviceNetworkConfig"
@@ -257,6 +299,10 @@
                                                             crown-function="CSK_DeviceNetworkConfig/addDNS"
                                                             protocol="crownMSGPACK">
                                                         </crown-set>
+                                                        <crown-edpws-binding property="disabled"
+                                                            name="CSK_DeviceNetworkConfig/OnNewStatusSetFunctionsNotSupported"
+                                                            update-on-resume>
+                                                        </crown-edpws-binding>
                                                     </davinci-button>
                                                     <davinci-button id="BTN_RemoveDns"
                                                         class="myCustomButton_CSK_Module_DeviceNetworkConfig"
@@ -267,6 +313,10 @@
                                                             crown-function="CSK_DeviceNetworkConfig/removeDNS"
                                                             protocol="crownMSGPACK">
                                                         </crown-set>
+                                                        <crown-edpws-binding property="disabled"
+                                                            name="CSK_DeviceNetworkConfig/OnNewStatusSetFunctionsNotSupported"
+                                                            update-on-resume>
+                                                        </crown-edpws-binding>
                                                     </davinci-button>
                                                 </layout-row>
                                             </layout-column>

--- a/CSK_Module_DeviceNetworkConfig/pages/pages/CSK_Module_DeviceNetworkConfig/CSK_Module_DeviceNetworkConfig.html
+++ b/CSK_Module_DeviceNetworkConfig/pages/pages/CSK_Module_DeviceNetworkConfig/CSK_Module_DeviceNetworkConfig.html
@@ -6,13 +6,12 @@
         <layout-row id="RowLayout20">
             <layout-column id="ColumnLayout17" style="align-items: stretch">
                 <layout-row id="RowLayout14" style="align-items: baseline">
-                    <davinci-value-display id="VD_Title" class="myCustomLabel_CSK_Module_DeviceNetworkConfig"
-                        value="Device Network Configuration">
-                    </davinci-value-display>
+                    <h1 id="Heading_Title" class="myCustomLabel_CSK_Module_DeviceNetworkConfig">
+                        Device Network Configuration
+                    </h1>
                     <davinci-value-display id="VD_Version">
-                        <crown-edpws-binding property="value" name="CSK_DeviceNetworkConfig/OnNewStatusModuleVersion"
-                            update-on-resume>
-                        </crown-edpws-binding>
+                        <crown-on property="value" crown-event="CSK_DeviceNetworkConfig/OnNewStatusModuleVersion">
+                        </crown-on>
                     </davinci-value-display>
                 </layout-row>
             </layout-column>
@@ -93,8 +92,8 @@
                                             <layout-column id="ColumnLayout14" style="align-items: center">
                                                 <davinci-button id="Button_Refresh"
                                                     class="myCustomButton_CSK_Module_DeviceNetworkConfig" type="outline"
-                                                    icon-position="append" icon="navigation/refresh"
                                                     title="Refresh list">
+                                                    <davinci-icon icon="navigation/refresh"></davinci-icon>
                                                     <span></span>
                                                     <crown-binding event="submit" name="CSK_DeviceNetworkConfig/refresh"
                                                         auto-commit>
@@ -104,10 +103,9 @@
                                             <layout-column id="ColumnLayout3" style="align-items: center">
                                                 <davinci-value-display id="VD_SelectedInterface"
                                                     class="myCustomMinWidth_CSK_Module_DeviceNetworkConfig">
-                                                    <crown-edpws-binding property="label"
-                                                        name="CSK_DeviceNetworkConfig/OnNewInterfaceChoice"
-                                                        update-on-resume>
-                                                    </crown-edpws-binding>
+                                                    <crown-on property="label"
+                                                        crown-event="CSK_DeviceNetworkConfig/OnNewInterfaceChoice">
+                                                    </crown-on>
                                                 </davinci-value-display>
                                             </layout-column>
                                             <layout-column id="ColumnLayout7"
@@ -209,8 +207,8 @@
                                             <layout-column id="ColumnLayout16" style="align-items: center">
                                                 <davinci-button id="Button_ApplyNewConfig"
                                                     class="myCustomButton_CSK_Module_DeviceNetworkConfig" type="outline"
-                                                    icon-position="append" title="Apply new network configuration"
-                                                    icon="navigation/check">
+                                                    title="Apply new network configuration">
+                                                    <davinci-icon icon="navigation/check"></davinci-icon>
                                                     <span></span>
                                                     <crown-edpws-binding property="disabled"
                                                         name="CSK_DeviceNetworkConfig/OnApplyButtonDisabled"
@@ -252,8 +250,8 @@
                                                 <layout-row id="RowLayout17">
                                                     <davinci-button id="BTN_AddDns"
                                                         class="myCustomButton_CSK_Module_DeviceNetworkConfig"
-                                                        type="outline" icon-position="append"
-                                                        title="Add the defined DNS" icon="content/add">
+                                                        type="outline" title="Add the defined DNS">
+                                                        <davinci-icon icon="content/add"></davinci-icon>
                                                         <span></span>
                                                         <crown-set event="submit"
                                                             crown-function="CSK_DeviceNetworkConfig/addDNS"
@@ -262,8 +260,8 @@
                                                     </davinci-button>
                                                     <davinci-button id="BTN_RemoveDns"
                                                         class="myCustomButton_CSK_Module_DeviceNetworkConfig"
-                                                        type="outline" icon-position="append"
-                                                        title="Remove the selected DNS entry" icon="action/delete">
+                                                        type="outline" title="Remove the selected DNS entry">
+                                                        <davinci-icon icon="action/delete"></davinci-icon>
                                                         <span></span>
                                                         <crown-set event="submit"
                                                             crown-function="CSK_DeviceNetworkConfig/removeDNS"
@@ -300,9 +298,9 @@
 														</span>
                                                     </davinci-callout>
                                                 </davinci-collapse>
-												<layout-row id="RowLayout21"
-													class="myCustomSpacerVert10_CSK_Module_DeviceNetworkConfig">
-												</layout-row>
+                                                <layout-row id="RowLayout21"
+                                                    class="myCustomSpacerVert10_CSK_Module_DeviceNetworkConfig">
+                                                </layout-row>
                                             </layout-column>
                                         </layout-row>
                                     </layout-column>
@@ -323,7 +321,8 @@
                                             </davinci-text-field>
                                             <davinci-button id="Button_Ping"
                                                 class="myCustomButton_CSK_Module_DeviceNetworkConfig" type="outline"
-                                                icon-position="append" title="PING" icon="content/send">
+                                                title="PING">
+                                                <davinci-icon icon="content/send"></davinci-icon>
                                                 <span></span>
                                                 <crown-set event="submit" crown-function="CSK_DeviceNetworkConfig/ping"
                                                     protocol="crownMSGPACK">
@@ -336,9 +335,9 @@
                                                 </crown-edpws-binding>
                                             </davinci-status-indicator>
                                             <davinci-value-display id="VD_PingDetails" style="align-self: center">
-                                                <crown-edpws-binding property="value"
-                                                    name="CSK_DeviceNetworkConfig/OnNewPingDetails" update-on-resume>
-                                                </crown-edpws-binding>
+                                                <crown-on property="value"
+                                                    crown-event="CSK_DeviceNetworkConfig/OnNewPingDetails">
+                                                </crown-on>
                                             </davinci-value-display>
                                         </layout-row>
                                     </layout-column>

--- a/CSK_Module_DeviceNetworkConfig/pages/src/converter.ts
+++ b/CSK_Module_DeviceNetworkConfig/pages/src/converter.ts
@@ -20,6 +20,14 @@ export function InvalidUpstreamIPv4Display(inState) {
 export function changeStyle(theme) {
   const style: HTMLStyleElement = document.createElement('style');
   style.id ='blub'
+
+  const toggleSW = document.querySelectorAll("davinci-toggle-switch")
+  toggleSW.forEach((userItem) => {
+    const shadowToggle = userItem.shadowRoot
+    const finalToggleSW = shadowToggle?.querySelector('div')
+    finalToggleSW?.classList.add('hasIcon')
+  });
+
   if (theme == 'CSK_Style'){
     var headerToolbar = `.sopasjs-ui-header-toolbar-wrapper { background-color: #FFFFFF; }`
     var uiHeader = `.sopasjs-ui-header>.app-logo { margin-right:0px; }`

--- a/CSK_Module_DeviceNetworkConfig/pages/src/index.ts
+++ b/CSK_Module_DeviceNetworkConfig/pages/src/index.ts
@@ -12,6 +12,10 @@ document.addEventListener('sopasjs-ready', () => {
   page_Setup.remove();
 
   setTimeout(() => {
-      document.title = 'CSK_Module_DeviceNetworkConfig'
+    const element = document.querySelector("div.sjs-wrapper > div > div.sjs-fullscreen-toggle")
+    if(element) {
+      element.parentElement.removeChild(element)
+    }
+    document.title = 'CSK_Module_DeviceNetworkConfig'
   }, 500);
 })

--- a/CSK_Module_DeviceNetworkConfig/project.mf.xml
+++ b/CSK_Module_DeviceNetworkConfig/project.mf.xml
@@ -227,7 +227,7 @@ See following descriptions of events/functions regarding further information.
             </serves>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">2.2.0</meta>
+        <meta key="version">2.2.1</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/CSK_Module_DeviceNetworkConfig/project.mf.xml
+++ b/CSK_Module_DeviceNetworkConfig/project.mf.xml
@@ -227,7 +227,7 @@ See following descriptions of events/functions regarding further information.
             </serves>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">2.2.1</meta>
+        <meta key="version">2.2.2</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/CSK_Module_DeviceNetworkConfig/project.mf.xml
+++ b/CSK_Module_DeviceNetworkConfig/project.mf.xml
@@ -132,6 +132,10 @@ See following descriptions of events/functions regarding further information.
                     <desc>Notify if module can be used on device.</desc>
                     <param desc="Status" multiplicity="1" name="status" type="bool"/>
                 </event>
+                <event name="OnNewStatusSetFunctionsNotSupported">
+                    <desc>Notify if module can not be used to set configuration (some devices only show current config).</desc>
+                    <param desc="Status" multiplicity="1" name="status" type="bool"/>
+                </event>
                 <function name="pageCalled">
                     <desc>Function to register "OnResume" of the module UI (only as helper function).</desc>
                     <return desc="Empty string (only needed to simplify binding)." multiplicity="1" name="empty" type="string"/>

--- a/CSK_Module_DeviceNetworkConfig/scripts/Configuration/DeviceNetworkConfig/DeviceNetworkConfig_Controller.lua
+++ b/CSK_Module_DeviceNetworkConfig/scripts/Configuration/DeviceNetworkConfig/DeviceNetworkConfig_Controller.lua
@@ -35,6 +35,7 @@ local deviceNetworkConfig_Model
 Script.serveEvent('CSK_DeviceNetworkConfig.OnNewStatusModuleVersion', 'DeviceNetworkConfig_OnNewStatusModuleVersion')
 Script.serveEvent('CSK_DeviceNetworkConfig.OnNewStatusCSKStyle', 'DeviceNetworkConfig_OnNewStatusCSKStyle')
 Script.serveEvent('CSK_DeviceNetworkConfig.OnNewStatusModuleIsActive', 'DeviceNetworkConfig_OnNewStatusModuleIsActive')
+Script.serveEvent('CSK_DeviceNetworkConfig.OnNewStatusSetFunctionsNotSupported', 'DeviceNetworkConfig_OnNewStatusSetFunctionsNotSupported')
 
 Script.serveEvent("CSK_DeviceNetworkConfig.OnNewStatusLoadParameterOnReboot", "DeviceNetworkConfig_OnNewStatusLoadParameterOnReboot")
 Script.serveEvent("CSK_DeviceNetworkConfig.OnPersistentDataModuleAvailable", "DeviceNetworkConfig_OnPersistentDataModuleAvailable")
@@ -332,6 +333,7 @@ local function handleOnExpiredTmrDeviceNetworkConfig()
   Script.notifyEvent("DeviceNetworkConfig_OnNewStatusModuleVersion", 'v' .. deviceNetworkConfig_Model.version)
   Script.notifyEvent("DeviceNetworkConfig_OnNewStatusCSKStyle", deviceNetworkConfig_Model.styleForUI)
   Script.notifyEvent("DeviceNetworkConfig_OnNewStatusModuleIsActive", _G.availableAPIs.default and _G.availableAPIs.specific)
+  Script.notifyEvent("DeviceNetworkConfig_OnNewStatusSetFunctionsNotSupported", _G.availableAPIs.noSetSupport)
 
   updateUserLevel()
 

--- a/CSK_Module_DeviceNetworkConfig/scripts/Configuration/DeviceNetworkConfig/DeviceNetworkConfig_Controller.lua
+++ b/CSK_Module_DeviceNetworkConfig/scripts/Configuration/DeviceNetworkConfig/DeviceNetworkConfig_Controller.lua
@@ -190,10 +190,6 @@ local function getNameserverList()
     end
   end
 
-  if #retValue == 0 then
-    table.insert(retValue, {dns= '-'})
-  end
-
   return retValue
 end
 
@@ -258,7 +254,11 @@ local function updateNameservers(nameserverList)
   CSK_DeviceNetworkConfig.sendParameters()
 
   -- Update DNS UI table
-  Script.notifyEvent("DeviceNetworkConfig_OnNewDNS", deviceNetworkConfig_Model.helperFuncs.json.encode(getNameserverList()))
+  local dnsList = deviceNetworkConfig_Model.helperFuncs.json.encode(getNameserverList())
+  if dnsList == '[]' or dnsList == '' then
+    dnsList = '[{"dns":"-"}]'
+  end
+  Script.notifyEvent("DeviceNetworkConfig_OnNewDNS", dnsList)
 end
 
 local function addDNS()
@@ -318,7 +318,11 @@ local function selectDNSViaUI(selectedRow)
 
   -- Workaround to reset the selection of the DNS in the UI table
   Script.sleep(100)
-  Script.notifyEvent("DeviceNetworkConfig_OnNewDNS", deviceNetworkConfig_Model.helperFuncs.json.encode(getNameserverList()))
+  local dnsList = deviceNetworkConfig_Model.helperFuncs.json.encode(getNameserverList())
+  if dnsList == '[]' or dnsList == '' then
+    dnsList = '[{"dns":"-"}]'
+  end
+  Script.notifyEvent("DeviceNetworkConfig_OnNewDNS", dnsList)
 end
 Script.serveFunction('CSK_DeviceNetworkConfig.selectDNSViaUI', selectDNSViaUI)
 
@@ -346,7 +350,12 @@ local function handleOnExpiredTmrDeviceNetworkConfig()
   Script.notifyEvent("DeviceNetworkConfig_OnNewDefaultGateway", '-')
   Script.notifyEvent("DeviceNetworkConfig_OnNewInterfaceChoice",'-')
   Script.notifyEvent("DeviceNetworkConfig_OnNewEthernetConfigStatus", 'empty')
-  Script.notifyEvent("DeviceNetworkConfig_OnNewDNS", deviceNetworkConfig_Model.helperFuncs.json.encode(getNameserverList()))
+  
+  local dnsList = deviceNetworkConfig_Model.helperFuncs.json.encode(getNameserverList())
+  if dnsList == '[]' or dnsList == '' then
+    dnsList = '[{"dns":"-"}]'
+  end
+  Script.notifyEvent("DeviceNetworkConfig_OnNewDNS", dnsList)
 
   Script.notifyEvent("DeviceNetworkConfig_OnNewStatusLoadParameterOnReboot", deviceNetworkConfig_Model.parameterLoadOnReboot)
   Script.notifyEvent("DeviceNetworkConfig_OnPersistentDataModuleAvailable", deviceNetworkConfig_Model.persistentModuleAvailable)

--- a/CSK_Module_DeviceNetworkConfig/scripts/Configuration/DeviceNetworkConfig/DeviceNetworkConfig_Model.lua
+++ b/CSK_Module_DeviceNetworkConfig/scripts/Configuration/DeviceNetworkConfig/DeviceNetworkConfig_Model.lua
@@ -81,6 +81,7 @@ local function refreshInterfaces()
   return deviceNetworkConfig_Model.interfacesTable
 end
 deviceNetworkConfig_Model.refreshInterfaces = refreshInterfaces
+refreshInterfaces()
 
 local function getNetworkDescription()
   if deviceNetworkConfig_Model.interfacesTable ~= {} then

--- a/CSK_Module_DeviceNetworkConfig/scripts/Configuration/DeviceNetworkConfig/helper/checkAPIs.lua
+++ b/CSK_Module_DeviceNetworkConfig/scripts/Configuration/DeviceNetworkConfig/helper/checkAPIs.lua
@@ -52,16 +52,16 @@ local function checkSetFunctionsNotSupported()
   local isSIM300 = string.find(deviceName, 'SIG300') or string.find(deviceName, 'SIM300')
   local isSAE = string.find(deviceName, 'AppEngine') or string.find(deviceName, 'Emulator')
   if isSIM300 or isSAE then
-    return false
-  else
     return true
+  else
+    return false
   end
 end
 
 availableAPIs.default = xpcall(loadAPIs, debug.traceback) -- TRUE if all default APIs were loaded correctly
 availableAPIs.specific = xpcall(loadSpecificAPIs, debug.traceback) -- TRUE if all specific APIs were loaded correctly
 availableAPIs.dateTime = xpcall(loadDateTimeAPIs, debug.traceback) -- TRUE if DateTime API was loaded correctly
-availableAPIs.noSetSupport = xpcall(checkSetFunctionsNotSupported, debug.traceback) -- TRUE if set function are not supported
+availableAPIs.noSetSupport = checkSetFunctionsNotSupported() -- TRUE if set function are not supported
 
 return availableAPIs
 --**************************************************************************

--- a/CSK_Module_DeviceNetworkConfig/scripts/Configuration/DeviceNetworkConfig/helper/checkAPIs.lua
+++ b/CSK_Module_DeviceNetworkConfig/scripts/Configuration/DeviceNetworkConfig/helper/checkAPIs.lua
@@ -46,9 +46,22 @@ local function loadDateTimeAPIs()
   DateTime = require 'API.DateTime'
 end
 
+-- Function to check if set features are not available
+local function checkSetFunctionsNotSupported()
+  local deviceName = Engine.getTypeName()
+  local isSIM300 = string.find(deviceName, 'SIG300') or string.find(deviceName, 'SIM300')
+  local isSAE = string.find(deviceName, 'AppEngine') or string.find(deviceName, 'Emulator')
+  if isSIM300 or isSAE then
+    return false
+  else
+    return true
+  end
+end
+
 availableAPIs.default = xpcall(loadAPIs, debug.traceback) -- TRUE if all default APIs were loaded correctly
 availableAPIs.specific = xpcall(loadSpecificAPIs, debug.traceback) -- TRUE if all specific APIs were loaded correctly
 availableAPIs.dateTime = xpcall(loadDateTimeAPIs, debug.traceback) -- TRUE if DateTime API was loaded correctly
+availableAPIs.noSetSupport = xpcall(checkSetFunctionsNotSupported, debug.traceback) -- TRUE if set function are not supported
 
 return availableAPIs
 --**************************************************************************

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For further information check out the [documentation](https://raw.githack.com/SI
 Tested on:
 |Device|Firmware|Module version|
 |--|--|--|
+|SIM800|V1.1.1|V2.2.2|
 |SICK AppEngine|V1.7.0|V2.2.0|
 |SIM1012|V2.4.2|V2.2.0|
 |SIM1000FX|V1.7.2|<V2.2.0|

--- a/docu/CSK_Module_DeviceNetworkConfig.html
+++ b/docu/CSK_Module_DeviceNetworkConfig.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_Module_DeviceNetworkConfig 2.2.1</title>
+<title>Documentation - CSK_Module_DeviceNetworkConfig 2.2.2</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,10 +615,10 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_Module_DeviceNetworkConfig 2.2.1</h1>
+<h1>Documentation - CSK_Module_DeviceNetworkConfig 2.2.2</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 2.2.1,</span>
+<span id="revnumber">version 2.2.2,</span>
 <span id="revdate">2024-12-05</span>
 </div>
 <div id="toc" class="toc2">
@@ -720,7 +720,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2.2.1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2.2.2</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
@@ -3221,7 +3221,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 2.2.1<br>
+Version 2.2.2<br>
 Last updated 2024-12-05 10:55:48 +0100
 </div>
 </div>

--- a/docu/CSK_Module_DeviceNetworkConfig.html
+++ b/docu/CSK_Module_DeviceNetworkConfig.html
@@ -619,7 +619,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
 <span id="revnumber">version 2.2.2,</span>
-<span id="revdate">2024-12-05</span>
+<span id="revdate">2025-07-18</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -681,6 +681,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <li><a href="#API:Event:CSK_DeviceNetworkConfig.OnNewStatusLoadParameterOnReboot"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnNewStatusLoadParameterOnReboot</span></a></li>
 <li><a href="#API:Event:CSK_DeviceNetworkConfig.OnNewStatusModuleIsActive"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnNewStatusModuleIsActive</span></a></li>
 <li><a href="#API:Event:CSK_DeviceNetworkConfig.OnNewStatusModuleVersion"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnNewStatusModuleVersion</span></a></li>
+<li><a href="#API:Event:CSK_DeviceNetworkConfig.OnNewStatusSetFunctionsNotSupported"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnNewStatusSetFunctionsNotSupported</span></a></li>
 <li><a href="#API:Event:CSK_DeviceNetworkConfig.OnNewSubnetMask"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnNewSubnetMask</span></a></li>
 <li><a href="#API:Event:CSK_DeviceNetworkConfig.OnPersistentDataModuleAvailable"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnPersistentDataModuleAvailable</span></a></li>
 <li><a href="#API:Event:CSK_DeviceNetworkConfig.OnSubnetDisabled"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnSubnetDisabled</span></a></li>
@@ -695,7 +696,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </li>
 <li><a href="#API:Crown:CSK_Module_DeviceNetworkConfig"><span class="api-crown">CSK_Module_DeviceNetworkConfig</span></a>
 <ul class="sectlevel3">
-<li><a href="#_short_description_54">Short description</a></li>
+<li><a href="#_short_description_55">Short description</a></li>
 <li><a href="#_overview_2">Overview</a></li>
 </ul>
 </li>
@@ -724,7 +725,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-12-05</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2025-07-18</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Author</p></th>
@@ -898,6 +899,9 @@ See following descriptions of events/functions regarding further information.</p
 </li>
 <li>
 <p><a href="#API:Event:CSK_DeviceNetworkConfig.OnNewStatusModuleVersion">OnNewStatusModuleVersion</a></p>
+</li>
+<li>
+<p><a href="#API:Event:CSK_DeviceNetworkConfig.OnNewStatusSetFunctionsNotSupported">OnNewStatusSetFunctionsNotSupported</a></p>
 </li>
 <li>
 <p><a href="#API:Event:CSK_DeviceNetworkConfig.OnNewSubnetMask">OnNewSubnetMask</a></p>
@@ -2818,15 +2822,63 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 </div>
 <div class="sect4">
-<h5 id="API:Event:CSK_DeviceNetworkConfig.OnNewSubnetMask"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnNewSubnetMask</span></h5>
+<h5 id="API:Event:CSK_DeviceNetworkConfig.OnNewStatusSetFunctionsNotSupported"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnNewStatusSetFunctionsNotSupported</span></h5>
 <div class="sect5">
 <h6 id="_short_description_46">Short description</h6>
+<div class="paragraph">
+<p>Notify if module can not be used to set configuration (some devices only show current config).</p>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_callback_arguments_22">Callback arguments</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_45">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewStatusSetFunctionsNotSupported</span>(status)
+  <span class="comment">-- Do something</span>
+<span class="keyword">end</span>
+
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_DeviceNetworkConfig.OnNewStatusSetFunctionsNotSupported</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnNewStatusSetFunctionsNotSupported</span><span class="delimiter">&quot;</span></span>)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Event:CSK_DeviceNetworkConfig.OnNewSubnetMask"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnNewSubnetMask</span></h5>
+<div class="sect5">
+<h6 id="_short_description_47">Short description</h6>
 <div class="paragraph">
 <p>Notify current subnet mask.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_22">Callback arguments</h6>
+<h6 id="_callback_arguments_23">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2853,7 +2905,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_45">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_46">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnNewSubnetMask</span>(SubnetMask)
@@ -2868,13 +2920,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_DeviceNetworkConfig.OnPersistentDataModuleAvailable"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnPersistentDataModuleAvailable</span></h5>
 <div class="sect5">
-<h6 id="_short_description_47">Short description</h6>
+<h6 id="_short_description_48">Short description</h6>
 <div class="paragraph">
 <p>Notify status if features of CSK_PersistendData module are available.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_23">Callback arguments</h6>
+<h6 id="_callback_arguments_24">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2901,7 +2953,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_46">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_47">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnPersistentDataModuleAvailable</span>(status)
@@ -2916,13 +2968,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_DeviceNetworkConfig.OnSubnetDisabled"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnSubnetDisabled</span></h5>
 <div class="sect5">
-<h6 id="_short_description_48">Short description</h6>
+<h6 id="_short_description_49">Short description</h6>
 <div class="paragraph">
 <p>Notified to disable / enable 'Subnet mask' text field in UI.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_24">Callback arguments</h6>
+<h6 id="_callback_arguments_25">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2949,7 +3001,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_47">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_48">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnSubnetDisabled</span>(isDisabled)
@@ -2964,13 +3016,13 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_DeviceNetworkConfig.OnSubnetError"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnSubnetError</span></h5>
 <div class="sect5">
-<h6 id="_short_description_49">Short description</h6>
+<h6 id="_short_description_50">Short description</h6>
 <div class="paragraph">
 <p>Highlights the 'Subnet' field in UI if format is not correct.</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_callback_arguments_25">Callback arguments</h6>
+<h6 id="_callback_arguments_26">Callback arguments</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2997,7 +3049,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </table>
 </div>
 <div class="sect5">
-<h6 id="_sample_auto_generated_48">Sample (auto-generated)</h6>
+<h6 id="_sample_auto_generated_49">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnSubnetError</span>(isError)
@@ -3012,57 +3064,9 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect4">
 <h5 id="API:Event:CSK_DeviceNetworkConfig.OnUserLevelAdminActive"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnUserLevelAdminActive</span></h5>
 <div class="sect5">
-<h6 id="_short_description_50">Short description</h6>
-<div class="paragraph">
-<p>Status of Admin userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_callback_arguments_26">Callback arguments</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 12.5%;">
-<col style="width: 37.5%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Multiplicity</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_sample_auto_generated_49">Sample (auto-generated)</h6>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelAdminActive</span>(status)
-  <span class="comment">-- Do something</span>
-<span class="keyword">end</span>
-
-Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_DeviceNetworkConfig.OnUserLevelAdminActive</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnUserLevelAdminActive</span><span class="delimiter">&quot;</span></span>)</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="API:Event:CSK_DeviceNetworkConfig.OnUserLevelMaintenanceActive"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnUserLevelMaintenanceActive</span></h5>
-<div class="sect5">
 <h6 id="_short_description_51">Short description</h6>
 <div class="paragraph">
-<p>Status of Maintenance userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
+<p>Status of Admin userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
 </div>
 </div>
 <div class="sect5">
@@ -3096,21 +3100,21 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <h6 id="_sample_auto_generated_50">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelMaintenanceActive</span>(status)
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelAdminActive</span>(status)
   <span class="comment">-- Do something</span>
 <span class="keyword">end</span>
 
-Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_DeviceNetworkConfig.OnUserLevelMaintenanceActive</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnUserLevelMaintenanceActive</span><span class="delimiter">&quot;</span></span>)</code></pre>
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_DeviceNetworkConfig.OnUserLevelAdminActive</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnUserLevelAdminActive</span><span class="delimiter">&quot;</span></span>)</code></pre>
 </div>
 </div>
 </div>
 </div>
 <div class="sect4">
-<h5 id="API:Event:CSK_DeviceNetworkConfig.OnUserLevelOperatorActive"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnUserLevelOperatorActive</span></h5>
+<h5 id="API:Event:CSK_DeviceNetworkConfig.OnUserLevelMaintenanceActive"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnUserLevelMaintenanceActive</span></h5>
 <div class="sect5">
 <h6 id="_short_description_52">Short description</h6>
 <div class="paragraph">
-<p>Status of Operator userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
+<p>Status of Maintenance userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
 </div>
 </div>
 <div class="sect5">
@@ -3144,21 +3148,21 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <h6 id="_sample_auto_generated_51">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelOperatorActive</span>(status)
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelMaintenanceActive</span>(status)
   <span class="comment">-- Do something</span>
 <span class="keyword">end</span>
 
-Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_DeviceNetworkConfig.OnUserLevelOperatorActive</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnUserLevelOperatorActive</span><span class="delimiter">&quot;</span></span>)</code></pre>
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_DeviceNetworkConfig.OnUserLevelMaintenanceActive</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnUserLevelMaintenanceActive</span><span class="delimiter">&quot;</span></span>)</code></pre>
 </div>
 </div>
 </div>
 </div>
 <div class="sect4">
-<h5 id="API:Event:CSK_DeviceNetworkConfig.OnUserLevelServiceActive"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnUserLevelServiceActive</span></h5>
+<h5 id="API:Event:CSK_DeviceNetworkConfig.OnUserLevelOperatorActive"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnUserLevelOperatorActive</span></h5>
 <div class="sect5">
 <h6 id="_short_description_53">Short description</h6>
 <div class="paragraph">
-<p>Status of Service userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
+<p>Status of Operator userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
 </div>
 </div>
 <div class="sect5">
@@ -3192,6 +3196,54 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <h6 id="_sample_auto_generated_52">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
+<pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelOperatorActive</span>(status)
+  <span class="comment">-- Do something</span>
+<span class="keyword">end</span>
+
+Script.register(<span class="string"><span class="delimiter">&quot;</span><span class="content">CSK_DeviceNetworkConfig.OnUserLevelOperatorActive</span><span class="delimiter">&quot;</span></span>, <span class="string"><span class="delimiter">&quot;</span><span class="content">handleOnUserLevelOperatorActive</span><span class="delimiter">&quot;</span></span>)</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="API:Event:CSK_DeviceNetworkConfig.OnUserLevelServiceActive"><span class="breadcrumb">CSK_DeviceNetworkConfig.</span><span class="api-event">OnUserLevelServiceActive</span></h5>
+<div class="sect5">
+<h6 id="_short_description_54">Short description</h6>
+<div class="paragraph">
+<p>Status of Service userlevel. Used internally in combination with the CSK_UserManagement module if available.</p>
+</div>
+</div>
+<div class="sect5">
+<h6 id="_callback_arguments_30">Callback arguments</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
+<h6 id="_sample_auto_generated_53">Sample (auto-generated)</h6>
+<div class="listingblock">
+<div class="content">
 <pre class="CodeRay highlight"><code data-lang="lua"><span class="keyword">function</span> <span class="function">handleOnUserLevelServiceActive</span>(status)
   <span class="comment">-- Do something</span>
 <span class="keyword">end</span>
@@ -3206,7 +3258,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div class="sect2">
 <h3 id="API:Crown:CSK_Module_DeviceNetworkConfig"><span class="api-crown">CSK_Module_DeviceNetworkConfig</span></h3>
 <div class="sect3">
-<h4 id="_short_description_54">Short description</h4>
+<h4 id="_short_description_55">Short description</h4>
 <div class="paragraph">
 <p>This is an automatically generated CROWN (description not necessary).</p>
 </div>
@@ -3222,7 +3274,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div id="footer">
 <div id="footer-text">
 Version 2.2.2<br>
-Last updated 2024-12-05 10:55:48 +0100
+Last updated 2025-07-18 17:40:31 +0200
 </div>
 </div>
 <script type="text/javascript">

--- a/docu/CSK_Module_DeviceNetworkConfig.html
+++ b/docu/CSK_Module_DeviceNetworkConfig.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_Module_DeviceNetworkConfig 2.2.0</title>
+<title>Documentation - CSK_Module_DeviceNetworkConfig 2.2.1</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,11 +615,11 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_Module_DeviceNetworkConfig 2.2.0</h1>
+<h1>Documentation - CSK_Module_DeviceNetworkConfig 2.2.1</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 2.2.0,</span>
-<span id="revdate">2024-07-31</span>
+<span id="revnumber">version 2.2.1,</span>
+<span id="revdate">2024-12-05</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -720,11 +720,11 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2.2.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2.2.1</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-07-31</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-12-05</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Author</p></th>
@@ -3221,8 +3221,8 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 2.2.0<br>
-Last updated 2024-07-31 16:12:12 +0200
+Version 2.2.1<br>
+Last updated 2024-12-05 10:55:48 +0100
 </div>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
# Release 2.2.2

## Bugfix
- Legacy bindings of ValueDisplay elements within UI did not work if deployed with VS Code AppSpace SDK
- UI differs if deployed via Appstudio or VS Code AppSpace SDK
- Fullscreen icon of iFrame was visible

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [ x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
